### PR TITLE
SB8200 eventlog scraping

### DIFF
--- a/boltdb/boltdb.go
+++ b/boltdb/boltdb.go
@@ -1,0 +1,198 @@
+package boltdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/pdunnavant/modem-scraper/config"
+	"github.com/pdunnavant/modem-scraper/scrape"
+
+	"github.com/boltdb/bolt"
+
+	"github.com/OneOfOne/xxhash"
+)
+
+// PruneEventLogs queries BoltDB for matching logs and removes them from
+// ModemInformation if found
+func PruneEventLogs(config config.BoltDB, modemInformation scrape.ModemInformation) (*scrape.ModemInformation, error) {
+
+	db, err := bolt.Open(config.Path, 0600, nil)
+	if err != nil {
+		fmt.Println(err)
+		return &modemInformation, nil
+	}
+	defer db.Close()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte("EventLogs"))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	var newEventLog []scrape.EventLog
+	for _, log := range modemInformation.EventLog {
+		hash := HashLog(log)
+		if !AlreadyLogged(db, log.DateTime, hash) {
+			//fmt.Printf("Preserving element %s\n", hash)
+			newEventLog = append(newEventLog, log)
+		}
+	}
+	modemInformation.EventLog = newEventLog
+
+	return &modemInformation, nil
+}
+
+// UpdateEventLogs queries BoltDB to write in the record of logs that have been
+// successfully written to InfluxDB and/or MQTT so that we do not rewrite later
+func UpdateEventLogs(config config.BoltDB, modemInformation scrape.ModemInformation) error {
+
+	db, err := bolt.Open(config.Path, 0600, nil)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	defer db.Close()
+
+	db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists([]byte("EventLogs"))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	hashMap := ArrangeHashes(modemInformation.EventLog)
+	hashMap = AppendFromExisting(db, hashMap)
+
+	db.Batch(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("EventLogs"))
+		for dateTime, hashes := range hashMap {
+			hashesJson, err := json.Marshal(hashes)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			err = b.Put([]byte(dateTime), hashesJson)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	return nil
+}
+
+func GetUniqueDateTimes(e []scrape.EventLog) []string {
+	dateTimes := []string{}
+	keys := make(map[string]bool)
+	for _, entry := range e {
+		if _, value := keys[entry.DateTime]; !value {
+			keys[entry.DateTime] = true
+			dateTimes = append(dateTimes, entry.DateTime)
+		}
+	}
+
+	return dateTimes
+}
+
+func ArrangeHashes(e []scrape.EventLog) map[string][]string {
+	dateTimes := GetUniqueDateTimes(e)
+	hashMap := make(map[string][]string)
+
+	for _, dateTime := range dateTimes {
+		for _, log := range e {
+			if log.DateTime == dateTime {
+				hash := HashLog(log)
+				if !ElementOf(hashMap[dateTime], hash) {
+					hashMap[dateTime] = append(hashMap[dateTime], hash)
+				}
+			}
+		}
+
+	}
+
+	return hashMap
+}
+
+func HashLog(log scrape.EventLog) string {
+	logConcat := log.DateTime + strconv.Itoa(log.EventID) + strconv.Itoa(log.EventLevel) + log.Description
+	logConcatHash := strconv.FormatUint(xxhash.Checksum64([]byte(logConcat)), 16)
+	return logConcatHash
+}
+
+func AppendFromExisting(db *bolt.DB, hashMap map[string][]string) map[string][]string {
+
+	var dbHashes []string
+	for dateTime, hashes := range hashMap {
+		db.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte("EventLogs"))
+			v := b.Get([]byte(dateTime))
+			if v != nil {
+				err := json.Unmarshal(v, &dbHashes)
+				if err != nil {
+					fmt.Println(err)
+					return err
+				}
+				//fmt.Printf("Initial hashes %v\n", dbHashes)
+				for _, hash := range dbHashes {
+					if !ElementOf(hashes, hash) {
+						hashMap[dateTime] = append(hashMap[dateTime], hash)
+					}
+				}
+				//fmt.Printf("Appended hashes %v\n", dbHashes)
+			}
+			return nil
+		})
+	}
+
+	return hashMap
+}
+
+func AlreadyLogged(db *bolt.DB, dateTime string, hash string) bool {
+
+	var dbHashes []string
+	found := false
+	db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte("EventLogs"))
+		v := b.Get([]byte(dateTime))
+		if v != nil {
+			err := json.Unmarshal(v, &dbHashes)
+			if err != nil {
+				fmt.Println(err)
+				return err
+			}
+			//fmt.Println(len(dbHashes))
+			if ElementOf(dbHashes, hash) {
+				found = true
+			}
+		}
+		return nil
+	})
+
+	return found
+}
+
+func ElementOf(slice []string, val string) bool {
+
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func PruneElement(slice []scrape.EventLog, index int) []scrape.EventLog {
+	slice[index] = slice[len(slice)-1]
+	slice[len(slice)-1] = scrape.EventLog{}
+	slice = slice[:len(slice)-1]
+	return slice
+}

--- a/config/config.go
+++ b/config/config.go
@@ -6,10 +6,12 @@ type Configuration struct {
 	PollSchedule string
 	MQTT         MQTT
 	InfluxDB     InfluxDB
+	BoltDB       BoltDB
 }
 
 // MQTT holds MQTT connection configuration.
 type MQTT struct {
+	Enabled  bool
 	Hostname string
 	Port     string
 	Username string
@@ -20,9 +22,15 @@ type MQTT struct {
 
 // InfluxDB holds InfluxDB connection configuration.
 type InfluxDB struct {
+	Enabled  bool
 	Hostname string
 	Port     string
 	Database string
 	Username string
 	Password string
+}
+
+// BoltDB holds BoltDB configuration.
+type BoltDB struct {
+	Path string
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/pdunnavant/modem-scraper
 go 1.12
 
 require (
+	github.com/OneOfOne/xxhash v1.2.7
 	github.com/PuerkitoBio/goquery v1.5.0
+	github.com/boltdb/bolt v1.3.1
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e
 	github.com/karrick/godirwalk v1.10.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/OneOfOne/xxhash v1.2.7 h1:fzrmmkskv067ZQbd9wERNGuxckWw67dyzoMG62p7LMo=
+github.com/OneOfOne/xxhash v1.2.7/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
 github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -10,6 +12,8 @@ github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9Pq
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -31,7 +31,7 @@ func Publish(config config.InfluxDB, modemInformation scrape.ModemInformation) e
 
 	batchPoints, _ := client.NewBatchPoints(client.BatchPointsConfig{
 		Database:  config.Database,
-		Precision: "s",
+		Precision: "ns",
 	})
 	points, err := modemInformation.ToInfluxPoints()
 	if err != nil {

--- a/scrape/eventlog.go
+++ b/scrape/eventlog.go
@@ -1,0 +1,102 @@
+package scrape
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	_ "github.com/influxdata/influxdb1-client" // this is important because of a bug in go mod
+	client "github.com/influxdata/influxdb1-client/v2"
+)
+
+const (
+	dateTimeLayout = "01/02/2006 15:04 MST"
+)
+
+// EventLog holds data pulled from the /cmeventlog.html page.
+type EventLog struct {
+	DateTime    string
+	EventID     int
+	EventLevel  int
+	Description string
+}
+
+// ToInfluxPoints converts EventLog to "points"
+func (e EventLog) ToInfluxPoints() ([]*client.Point, error) {
+	var points []*client.Point
+
+	// No tags for this specific struct.
+	tags := map[string]string{}
+	fields := map[string]interface{}{
+		"date_time":   e.DateTime,
+		"event_id":    e.EventID,
+		"event_level": e.EventLevel,
+		"description": e.Description,
+	}
+	point, err := client.NewPoint("event_log", tags, fields, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("error generating points data for EventLog: %s", err.Error())
+	}
+
+	points = append(points, point)
+
+	return points, nil
+}
+
+const eventLogTableSelector = "#bg3 > div.container > div.content > form > center > table"
+
+func scrapeEventLogs(doc *goquery.Document) []EventLog {
+	eventLogTable := doc.Find(eventLogTableSelector)
+	eventLogTableTbody := eventLogTable.Children()
+	eventLogTableTbodyRows := eventLogTableTbody.Children()
+
+	eventLogs := []EventLog{}
+	eventLogTableTbodyRows.Each(func(index int, row *goquery.Selection) {
+		// Skip the "title" row as well as the "header" row.
+		// These are both regular old <tr> rows on this page.
+		if index > 0 {
+			eventLogs = append(eventLogs, makeEventLog(row))
+		}
+	})
+
+	return eventLogs
+}
+
+func makeEventLog(selection *goquery.Selection) EventLog {
+	rowData := selection.Children()
+	eventLog := EventLog{
+		DateTime:    rowData.Get(0).FirstChild.Data,
+		EventID:     getIntRowData(rowData, 1),
+		EventLevel:  getIntRowData(rowData, 2),
+		Description: rowData.Get(3).FirstChild.Data,
+	}
+
+	eventLog.DateTime, _ = formatTime(eventLog.DateTime)
+
+	return eventLog
+}
+
+func formatTime(datetime string) (string, error) {
+	now := time.Now()
+	zone, _ := now.Zone()
+	t, err := time.Parse(dateTimeLayout, datetime+" "+zone)
+	if err != nil {
+		fmt.Println(err)
+		return datetime, err
+	}
+	return t.Format(time.RFC3339), nil
+}
+
+func buildEventLogPoints(logs []EventLog) ([]*client.Point, error) {
+	var points []*client.Point
+
+	for _, log := range logs {
+		influxPoints, err := log.ToInfluxPoints()
+		if err != nil {
+			return nil, err
+		}
+		points = append(points, influxPoints...)
+	}
+
+	return points, nil
+}

--- a/scrape/modeminformation.go
+++ b/scrape/modeminformation.go
@@ -12,6 +12,7 @@ import (
 type ModemInformation struct {
 	ConnectionStatus    ConnectionStatus
 	SoftwareInformation SoftwareInformation
+	EventLog            []EventLog
 }
 
 // ToJSON converts ModemInformation to JSON string.
@@ -47,6 +48,12 @@ func (m ModemInformation) ToInfluxPoints() ([]*client.Point, error) {
 	points = append(points, influxPoints...)
 
 	influxPoints, err = m.SoftwareInformation.ToInfluxPoints()
+	if err != nil {
+		return nil, err
+	}
+	points = append(points, influxPoints...)
+
+	influxPoints, err = buildEventLogPoints(m.EventLog)
 	if err != nil {
 		return nil, err
 	}

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -25,9 +25,16 @@ func Scrape(config config.Configuration) (*ModemInformation, error) {
 	}
 	softwareInformation := scrapeSoftwareInformation(doc)
 
+	doc, err = getDocumentFromURL(config.IP + "/cmeventlog.html")
+	if err != nil {
+		return nil, err
+	}
+	eventLog := scrapeEventLogs(doc)
+
 	modemInformation := ModemInformation{
 		ConnectionStatus:    *connectionStatus,
 		SoftwareInformation: *softwareInformation,
+		EventLog:            eventLog,
 	}
 	// fmt.Printf("%# v", pretty.Formatter(modemInformation))
 


### PR DESCRIPTION
This PR implements the following

* Allows toggling InfluxDB and MQTT output via configuration instead of always sending to both
* Utilize BoltDB and add configuration options for it
* MVP for scraping `/cmeventlog.html` to read all event logs, checking to see if they have been recorded in a local boltdb instance and if not recording them to that instance, and then writing any new logs to the configured outputs
* Changes InfluxDB precision to nanoseconds which is important for recording logs without deduplicating distinct logs