### PR TITLE
revise configuration to attempt to improve clarity and add sample config

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,43 @@
+# Modem configuration
+modem:
+  # URL pointing to the modem
+  url: http://192.168.100.1
+
+# Polling configuration
+polling:
+  # Cron schedule on which to poll, see https://godoc.org/github.com/robfig/cron 
+  schedule: "*/15 * * * *"
+
+# InfluxDB Configuration
+influxdb:
+  # Whether or not to submit data to InfluxDB
+  enabled: true
+  # URL where InfluxDB is listening on its HTTP API
+  url: http://localhost:8086
+  # InfluxDB database to use
+  database: modem
+  # Credentials for authentication (omit if unauthenticated)
+  username: user
+  password: pass
+
+# MQTT configuration
+mqtt:
+  # Whether or not to submit data to MQTT
+  enabled: true
+  # Hostname or IP where MQTT is running
+  hostname: localhost
+  # Listening port for MQTT
+  port: 1883
+  # Credentials for authentication
+  username: user
+  password: pass
+  # MQTT topic to use
+  topic: modem
+  # Client ID for MQTT communication
+  clientid: modem-scraper
+
+# BoltDB configuration
+boltdb:
+  # Local filesystem path where the BoltDB db file should reside
+  path: /var/lib/modem-scraper/modem-scraper.db
+

--- a/config/config.go
+++ b/config/config.go
@@ -2,11 +2,21 @@ package config
 
 // Configuration holds all configuration for modem-scraper.
 type Configuration struct {
-	IP           string
-	PollSchedule string
-	MQTT         MQTT
-	InfluxDB     InfluxDB
-	BoltDB       BoltDB
+	Modem    Modem
+	Polling  Polling
+	MQTT     MQTT
+	InfluxDB InfluxDB
+	BoltDB   BoltDB
+}
+
+// Modem holds modem configuration
+type Modem struct {
+	Url string
+}
+
+// Polling holds polling configuration
+type Polling struct {
+	Schedule string
 }
 
 // MQTT holds MQTT connection configuration.
@@ -23,8 +33,7 @@ type MQTT struct {
 // InfluxDB holds InfluxDB connection configuration.
 type InfluxDB struct {
 	Enabled  bool
-	Hostname string
-	Port     string
+	Url      string
 	Database string
 	Username string
 	Password string

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -16,11 +16,9 @@ import (
 func Publish(config config.InfluxDB, modemInformation scrape.ModemInformation) error {
 	start := time.Now()
 
-	addr := makeAddr(config.Hostname, config.Port)
-
-	fmt.Printf("Connecting to InfluxDB server [%s]...\n", addr)
+	fmt.Printf("Connecting to InfluxDB server [%s]...\n", config.Url)
 	influx, err := client.NewHTTPClient(client.HTTPConfig{
-		Addr:     addr,
+		Addr:     config.Url,
 		Username: config.Username,
 		Password: config.Password,
 	})

--- a/modem-scraper.go
+++ b/modem-scraper.go
@@ -46,7 +46,7 @@ func main() {
 	}
 
 	c := cron.New()
-	c.AddFunc(configuration.PollSchedule, func() {
+	c.AddFunc(configuration.Polling.Schedule, func() {
 		fmt.Println("Waking up...")
 		modemInformation, err := scrape.Scrape(*configuration)
 		if err != nil {

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -13,19 +13,19 @@ import (
 
 // Scrape scrapes data from the modem.
 func Scrape(config config.Configuration) (*ModemInformation, error) {
-	doc, err := getDocumentFromURL(config.IP + "/cmconnectionstatus.html")
+	doc, err := getDocumentFromURL(config.Modem.Url + "/cmconnectionstatus.html")
 	if err != nil {
 		return nil, err
 	}
 	connectionStatus := scrapeConnectionStatus(doc)
 
-	doc, err = getDocumentFromURL(config.IP + "/cmswinfo.html")
+	doc, err = getDocumentFromURL(config.Modem.Url + "/cmswinfo.html")
 	if err != nil {
 		return nil, err
 	}
 	softwareInformation := scrapeSoftwareInformation(doc)
 
-	doc, err = getDocumentFromURL(config.IP + "/cmeventlog.html")
+	doc, err = getDocumentFromURL(config.Modem.Url + "/cmeventlog.html")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Revise configuration file parameters to try to improve clarity; for instance instead of "ip" the config now specifies that this is the url of the modem's status page. InfluxDB is improved by stating that we want a URL instead of a hostname and IP (previous behavior always implicitly defaulted to http and it was not obvious how to send to an InfluxDB instance using TLS).